### PR TITLE
Fix/bug mt940 import fails when currency marker is not cr or dr #11

### DIFF
--- a/src/utils/data/mt940import_utils.py
+++ b/src/utils/data/mt940import_utils.py
@@ -77,6 +77,7 @@ def parse_block(blocks: list) -> list:
     temp_date = None
     temp_bookingdate = None
     temp_amount_type = None
+    temp_currency = None
     temp_amount = None
     temp_purpose_adition = None
     temp_purpose = None
@@ -110,6 +111,7 @@ def parse_block(blocks: list) -> list:
                 transaction['OpeningBalance'] = temp_opening_balance
                 transaction['Date'] = temp_date
                 transaction['Bookingdate'] = temp_bookingdate
+                transaction['Currency'] = temp_currency
                 transaction['Amount'] = temp_amount
                 transaction['TransactionTypeNumber'] = (
                     temp_transaction_type_number
@@ -127,10 +129,17 @@ def parse_block(blocks: list) -> list:
             # =========== Date ===========
             temp_date = block[:6]
             temp_bookingdate = block[6:10]
-            # =========== Amount ===========
+            # =========== Amount-Typ (+/-) ===========
             # 1 => +; 0 => -
             temp_amount_type = (1 if block[10:11] in ("C") or
                                 block[10:12] in ("RD") else -1)
+            # =========== Currency ===========
+            if block[10:12] == "RC" or block[10:12] == "RD":
+                currency_position = 12
+            else:  # "C" or "D"
+                currency_position = 11
+            temp_currency = block[currency_position]
+            # =========== Amount ===========
             # Find the start of the amount by searching for the
             # first digit after position 13
             amount_start = None

--- a/src/utils/data/mt940import_utils.py
+++ b/src/utils/data/mt940import_utils.py
@@ -141,7 +141,7 @@ def parse_block(blocks: list) -> list:
             temp_currency = block[currency_position]
             # =========== Amount ===========
             # Find the start of the amount by searching for the
-            # first digit after position 13
+            # first digit after position 11
             amount_start = None
             for idx, char in enumerate(block[11:], start=11):
                 if char.isdigit():

--- a/src/utils/data/mt940import_utils.py
+++ b/src/utils/data/mt940import_utils.py
@@ -129,12 +129,16 @@ def parse_block(blocks: list) -> list:
             temp_bookingdate = block[6:10]
             # =========== Amount ===========
             # 1 => +; 0 => -
-            temp_amount_type = 1 if block[11:12] in ("C", "RD") else -1
-            if 'CR' in block:
-                amount_start = block.find('CR') + 2
-            elif 'DR' in block:
-                amount_start = block.find('DR') + 2
-            else:
+            temp_amount_type = (1 if block[10:11] in ("C") or
+                                block[10:12] in ("RD") else -1)
+            # Find the start of the amount by searching for the
+            # first digit after position 13
+            amount_start = None
+            for idx, char in enumerate(block[11:], start=11):
+                if char.isdigit():
+                    amount_start = idx
+                    break
+            if amount_start is None:
                 logger.error("No amount found")
             if 'S' in block:
                 amount_end_search_param = 'S'

--- a/src/utils/data/mt940import_utils.py
+++ b/src/utils/data/mt940import_utils.py
@@ -131,8 +131,8 @@ def parse_block(blocks: list) -> list:
             temp_bookingdate = block[6:10]
             # =========== Amount-Type (+/-) ===========
             # 1 => +; 0 => -
-            temp_amount_type = (1 if block[10:11] in ("C") or
-                                block[10:12] in ("RD") else -1)
+            temp_amount_type = (1 if block[10] == 'C' or
+                                block[10:12] == 'RD' else -1)
             # =========== Currency ===========
             if block[10:12] == "RC" or block[10:12] == "RD":
                 currency_position = 12

--- a/src/utils/data/mt940import_utils.py
+++ b/src/utils/data/mt940import_utils.py
@@ -129,7 +129,7 @@ def parse_block(blocks: list) -> list:
             # =========== Date ===========
             temp_date = block[:6]
             temp_bookingdate = block[6:10]
-            # =========== Amount-Typ (+/-) ===========
+            # =========== Amount-Type (+/-) ===========
             # 1 => +; 0 => -
             temp_amount_type = (1 if block[10:11] in ("C") or
                                 block[10:12] in ("RD") else -1)


### PR DESCRIPTION
This pull request introduces enhancements to the `parse_block` function in `src/utils/data/mt940import_utils.py` to improve transaction parsing by adding support for currency extraction and refining the handling of amount types and positions. The most important changes include adding a new `temp_currency` variable, updating logic to extract currency, and improving the detection of amount start positions.

### Enhancements to transaction parsing:

* **Currency extraction support:**
  - Added a new `temp_currency` variable to store the transaction currency. This variable is now included in the parsed transaction dictionary under the key `Currency`. [[1]](diffhunk://#diff-1f70dbeaf7c4f87d1b5c674f0b98060f6f60b137af20210d3bcbd2ec905b7e20R80) [[2]](diffhunk://#diff-1f70dbeaf7c4f87d1b5c674f0b98060f6f60b137af20210d3bcbd2ec905b7e20R114)
  - Introduced logic to determine the position of the currency code based on the transaction type (`RC`, `RD`, `C`, `D`) and extract the currency from the block.

* **Refined amount type and position handling:**
  - Adjusted the logic for determining the `temp_amount_type` to handle specific transaction codes (`C`, `RD`, etc.) more accurately.
  - Improved the detection of the starting position of the amount by iterating through the block to find the first digit after position 11, ensuring robustness in parsing.

### Development
Closes #11